### PR TITLE
2x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/pepperfm/filament-json/fix-php-code-styling.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/pepperfm/filament-json/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/pepperfm/filament-json.svg?style=flat-square)](https://packagist.org/packages/pepperfm/filament-json)
 
-
-# [Documentation on my doc. website](https://docs.pepperfm.com/filament-json)
-
 ## Installation
+
+[Documentation on my doc. website](https://docs.pepperfm.com/filament-json)
 
 You can install the package via composer:
 
@@ -111,6 +110,7 @@ class ModalConfigDto
 ## Testing
 
 ```bash
+
 composer test
 ```
 
@@ -121,10 +121,6 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Contributing
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
-
-## Security Vulnerabilities
-
-Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -46,16 +46,17 @@ JsonColumn::make('properties')
 ```php
 use PepperFM\FilamentJson\Columns\JsonColumn;
 
-$buttonConfig = [
-    'color' => 'warning',
-    'size' => 'xs',
-];
-$modalConfig = literal(
-    icon: 'heroicon-m-sparkles',
-    alignment: 'start',
-    width: 'xl',
-    closedButton: false,
+$buttonConfig = literal(
+    color: 'primary',
+    size: 'xs'
 );
+$modalConfig = [
+    'icon' => 'heroicon-m-sparkles',
+    'alignment' => 'start',
+    'width' => 'xl',
+    'closedByEscaping' => true,
+    'closed_button' => false, // also accepts camel_case
+];
 
 JsonColumn::make('properties')
     ->asModal()

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ JsonColumn::make('properties')
     ->asModal();
 ```
 
-### Customize button and modal props:
+### Customize button and modal props
+> [!IMPORTANT]
+> The `button()` and `modal()` method accept the type of `array|Arrayable|\stdClass`, and implements basic properties of button and modal blade components from Filament documentation: Core Concepts - Blade Components
+
 ```php
 use PepperFM\FilamentJson\Columns\JsonColumn;
 
@@ -63,9 +66,6 @@ JsonColumn::make('properties')
     ->button($buttonConfig)
     ->modal($modalConfig);
 ```
-> [!IMPORTANT]
-> The `button()` and `modal()` method accept the type of `array|Arrayable|\stdClass`, and implements basic properties of button and modal blade components from Filament documentation: Core Concepts - Blade Components
-
 #### DTO schemas of components configuration:
 ```php
 class ButtonConfigDto

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.2",
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/support": "^10.45|^11.0"
+        "illuminate/support": ">=10.45"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.59",

--- a/resources/views/_partials/nested.blade.php
+++ b/resources/views/_partials/nested.blade.php
@@ -1,16 +1,42 @@
 @props([
     'items' => [],
+    'depth' => 1,
+    'maxDepth' => 3,
 ])
 
-<span class="whitespace-normal divide-x divide-gray-200 divide-solid dark:divide-gray-700">
-@foreach ($items as $nestedKey => $nestedValue)
-    <span class="inline-block mr-1">
-        {{ $nestedKey }}:
-        @if(is_array($nestedValue) || $nestedValue instanceof \Illuminate\Contracts\Support\Arrayable)
-            @include('filament-json::_partials.nested', ['items' => $nestedValue])
-        @else
-            {{ $applyLimit($nestedValue) }}
-        @endif
-    </span>
-@endforeach
-</span>
+@php
+    $isNestingEnabled = $depth < $maxDepth;
+@endphp
+
+<div>
+    @foreach ($items as $nestedKey => $nestedValue)
+        <div
+            @class([
+                'block' => !$isNestingEnabled,
+                'flex' => $isNestingEnabled,
+                'justify-center p-4 my-2 shadow border border-gray-300 dark:border-gray-600 rounded-md',
+           ])
+        >
+            <pre
+                @class([
+                    'block border-b border-gray-200 dark:border-gray-600' => !$isNestingEnabled,
+               ])
+            >{{ $nestedKey }}: </pre>
+            @if (is_array($nestedValue) || $nestedValue instanceof \Illuminate\Contracts\Support\Arrayable)
+                @if ($isNestingEnabled)
+                    <div class="p-2 border border-gray-200 dark:border-gray-600 rounded-md mt-2">
+                        @include('filament-json::_partials.nested', [
+                            'items' => $nestedValue,
+                            'depth' => $depth + 1,
+                            'maxDepth' => $maxDepth,
+                        ])
+                    </div>
+                @else
+                    <span class="text-gray-500">[Data truncated]</span>
+                @endif
+            @else
+                <pre>{{ $applyLimit($nestedValue) }}</pre>
+            @endif
+        </div>
+    @endforeach
+</div>

--- a/resources/views/json.blade.php
+++ b/resources/views/json.blade.php
@@ -1,14 +1,24 @@
 @php
+    /** @var ?int $characterLimit */
     $characterLimit = $getCharacterLimit();
+    /** @var bool $asModal */
     $asModal = $getAsModal();
+    /** @var bool $asDrawer */
     $asDrawer = $getAsDrawer();
+
+    /** @var string $keyColumnLabel */
+    $keyColumnLabel = $getKeyColumnLabel();
+    /** @var string $valueColumnLabel */
+    $valueColumnLabel = $getValueColumnLabel();
 
     /** @var \PepperFM\FilamentJson\Dto\ButtonConfigDto $buttonConfig */
     $buttonConfig = $getButtonConfig();
     /** @var \PepperFM\FilamentJson\Dto\ModalConfigDto $modalConfig */
     $modalConfig = $getModalConfig();
+
+    $maxDepth = 2;
 @endphp
-@if($asModal)
+@if($asModal || $asDrawer)
     <x-filament::modal
         :id="$modalConfig->id"
         :icxon="$modalConfig->icon"
@@ -18,7 +28,7 @@
         :close-by-clicking-away="$modalConfig->closeByClickingAway"
         :close-by-escaping="$modalConfig->closedByEscaping"
         :close-button="$modalConfig->closedButton"
-        :slide-over="$asDrawer"
+        :slide-over="$asDrawer && !$asModal"
     >
         <x-slot name="trigger">
             <x-filament::icon-button
@@ -33,26 +43,30 @@
         </x-slot>
 
         <div class="my-2 text-sm tracking-tight divide-y divide-gray-200 dark:divide-white/10">
-            <table
-                class="w-full table-auto divide-y divide-gray-200 dark:divide-white/5"
-            >
+            <table class="w-full table-auto divide-y divide-gray-200 dark:divide-white/5">
                 <thead>
                     <tr>
-                        <th class="px-3 py-2 w-1/2 text-center text-sm font-medium text-gray-700 dark:text-gray-200">Key
+                        <th class="px-3 py-2 w-1/2 text-center text-sm font-medium text-gray-700 dark:text-gray-200">
+                            {{ $keyColumnLabel }}
                         </th>
-                        <th class="px-3 py-2 w-1/2 text-center text-sm font-medium text-gray-700 dark:text-gray-200">Value
+                        <th class="px-3 py-2 w-1/2 text-center text-sm font-medium text-gray-700 dark:text-gray-200">
+                            {{ $valueColumnLabel }}
                         </th>
                     </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-200 dark:divide-white/5">
                 @foreach($getState() as $key => $value)
                     <tr class="divide-x divide-gray-200 dark:divide-white/5 rtl:divide-x-reverse">
-                        <td class="font-mono py-2">
-                            {{ $key }}
-                        </td>
-                        <td class="font-mono whitespace-normal p-2">
+                        <td class="font-mono py-2 ">{{ $key }}</td>
+                        <td class="font-mono whitespace-normal p-2 border-b border-gray-300 dark:border-white">
                             @if(is_array($value) || $value instanceof \Illuminate\Contracts\Support\Arrayable)
-                                @include('filament-json::_partials.nested', ['items' => $value])
+                                <div class="nested-value-container p-2 border border-gray-200 dark:border-gray-600 rounded-md mt-2">
+                                    @include('filament-json::_partials.nested', [
+                                        'items' => $value,
+                                        'depth' => 1,
+                                        'maxDepth' => $maxDepth,
+                                    ])
+                                </div>
                             @else
                                 <span class="whitespace-normal">{{ $applyLimit($value) }}</span>
                             @endif

--- a/src/Columns/JsonColumn.php
+++ b/src/Columns/JsonColumn.php
@@ -17,7 +17,13 @@ class JsonColumn extends TextColumn
 
     protected bool $asModal = false;
 
-    protected bool $asDrawer = false;
+    protected bool $asDrawer = true;
+
+    protected bool $filterNullable = true;
+
+    protected string $keyColumnLabel = 'Key';
+
+    protected string $valueColumnLabel = 'Value';
 
     protected ButtonConfigDto $buttonConfig;
 
@@ -45,6 +51,7 @@ class JsonColumn extends TextColumn
 
     public function asModal(bool $condition = true): static
     {
+        $this->asDrawer = false;
         $this->asModal = $condition;
 
         return $this;
@@ -52,7 +59,7 @@ class JsonColumn extends TextColumn
 
     public function asDrawer(bool $condition = true): static
     {
-        $this->asModal = $condition;
+        $this->asModal = false;
         $this->asDrawer = $condition;
 
         return $this;
@@ -77,6 +84,37 @@ class JsonColumn extends TextColumn
         return $this;
     }
 
+    public function keyColumnLabel(string $label = 'Key'): static
+    {
+        $this->keyColumnLabel = $label;
+
+        return $this;
+    }
+
+    public function getKeyColumnLabel(): string
+    {
+        return $this->keyColumnLabel;
+    }
+
+    public function valueColumnLabel(string $label = 'Value'): static
+    {
+        $this->valueColumnLabel = $label;
+
+        return $this;
+    }
+
+    public function getValueColumnLabel(): string
+    {
+        return $this->valueColumnLabel;
+    }
+
+    public function filterNullable(?bool $value = true): static
+    {
+        $this->filterNullable = $value;
+
+        return $this;
+    }
+
     public function getModalConfig(): ModalConfigDto
     {
         return $this->modalConfig;
@@ -90,6 +128,11 @@ class JsonColumn extends TextColumn
     public function getAsDrawer(): bool
     {
         return $this->asDrawer;
+    }
+
+    public function getFilterNullable(): bool
+    {
+        return $this->filterNullable;
     }
 
     public function getState(): mixed
@@ -112,10 +155,16 @@ class JsonColumn extends TextColumn
             $state = $this->getDefaultState();
         }
         if ($state instanceof Collection) {
-            $state = $state->filter()->take($listLimit);
+            $state = $state->when(
+                value: $this->getFilterNullable(),
+                callback: static fn($collection) => $collection->filter()
+            )->take($listLimit);
         }
         if (is_array($state)) {
-            $state = collect($state)->filter()->take($listLimit);
+            $state = collect($state)->when(
+                value: $this->getFilterNullable(),
+                callback: static fn($collection) => $collection->filter()
+            )->take($listLimit);
         }
 
         return $state;


### PR DESCRIPTION
# Added feature to display nested data with maxDepth = 2

This json content
```json
{
  "ip": "127.0.0.1",
  "subdata": {
    "1": 321,
    "wow": "123"
  },
  "user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 YaBrowser/25.2.0.0 Safari/537.36",
  "fingerprint": null,
  "subDataArray": [
    1,
    2,
    "test"
  ]
}
  ```
should looks like:
![image](https://github.com/user-attachments/assets/ede77bb3-bea9-4e98-ad40-1996e2ef2122)
---
This json content with this nesting level
```json
{
  "more_nested_array": [
    "scroll_checking",
    "scroll_checking2",
    {
      "scroll_checking_2_1": 1,
      "scroll_checking_2_2": {
        "data": {
          "some_bool_key": true
        }
      }
    }
  ],
  "arrayWithRandomSubData": [
    1,
    "2",
    {
      "1": 1,
      "2": "qweqwe",
      "response": {
        "data": {
          "some_bool_key": true
        }
      }
    }
  ]
}
  ```
  
 should looks like:
 
![image](https://github.com/user-attachments/assets/e5def208-8432-4498-8e22-fca9d700c487)
